### PR TITLE
Update ViaQ repo to match OpenShift Origin 1.5

### DIFF
--- a/centos7-viaq.repo
+++ b/centos7-viaq.repo
@@ -1,26 +1,6 @@
-[centos-openshift-origin]
-name=CentOS OpenShift Origin
-baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/
+[centos-openshift-origin-15]
+name=CentOS 7 - OpenShift Origin 1.5
+baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin15/
 enabled=1
 gpgcheck=1
-gpgkey=https://tdawson.fedorapeople.org/centos/RPM-GPG-KEY-CentOS-SIG-PaaS
-
-[centos-openshift-common-candidate]
-name=CentOS OpenShift Common Candidate
-baseurl=https://cbs.centos.org/repos/paas7-openshift-common-candidate/x86_64/os/
-enabled=0
-gpgcheck=0
-
-[centos-openshift-origin14-candidate]
-name=CentOS OpenShift Origin14 Candidate
-baseurl=http://cbs.centos.org/repos/paas7-openshift-origin14-candidate/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=https://tdawson.fedorapeople.org/centos/RPM-GPG-KEY-CentOS-SIG-PaaS
-
-[centos-openshift-origin15-candidate]
-name=CentOS OpenShift Origin15 Candidate
-baseurl=http://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=https://tdawson.fedorapeople.org/centos/RPM-GPG-KEY-CentOS-SIG-PaaS
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS


### PR DESCRIPTION
Update ViaQ repo to match OpenShift Origin 1.5
Basic install tested.