### PR TITLE
add documentation about using persistent storage

### DIFF
--- a/ansible-inventory-origin-36-aio
+++ b/ansible-inventory-origin-36-aio
@@ -21,10 +21,12 @@ deployment_type=origin
 openshift_logging_es_allow_external=True
 openshift_logging_use_mux=True
 openshift_logging_mux_allow_external=True
-openshift_logging_mux_client_mode=maximal
 openshift_check_min_host_memory_gb=7
 openshift_check_min_host_disk_gb=14
 openshift_disable_check="package_version,docker_storage"
+openshift_logging_mux_file_buffer_storage_type=hostmount
+openshift_logging_elasticsearch_storage_type=hostmount
+openshift_logging_elasticsearch_hostmount_path=/var/lib/elasticsearch
 
 [nodes]
 localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True

--- a/vars.yaml.template
+++ b/vars.yaml.template
@@ -45,8 +45,12 @@ openshift_logging_es_hostname: es.{{ openshift_master_default_subdomain }}
 openshift_logging_mux_hostname: mux.{{ openshift_master_default_subdomain }}
 
 # mux tuning parameters
+#openshift_logging_mux_file_buffer_limit: 2Gi
 openshift_logging_mux_cpu_limit: 500m
 #openshift_logging_mux_memory_limit: 2Gi
 #openshift_logging_mux_buffer_queue_limit: 1024
 openshift_logging_mux_buffer_size_limit: 16m
 #openshift_logging_mux_replicas: 1
+
+# fluentd tuning parameters
+#openshift_logging_fluentd_file_buffer_limit: 1Gi


### PR DESCRIPTION
persistent storage is now used by default.  Unfortunately, this requires
some additional steps both before and after installation.