### PR TITLE
Add logging setup instructions for 3.7

### DIFF
--- a/README-install.md
+++ b/README-install.md
@@ -123,11 +123,11 @@ openshift-ansible-roles
       openshift-ansible-lookup-plugins openshift-ansible-playbooks \
       openshift-ansible-roles
 
-If the 3.6 version of these packages are not available, you can use the
+If the 3.7 version of these packages are not available, you can use the
 git repo `https://github.com/openshift/openshift-ansible.git` and the
-`release-3.6` branch:
+`release-3.7` branch:
 
-    # git clone https://github.com/openshift/openshift-ansible.git -b release-3.6
+    # git clone https://github.com/openshift/openshift-ansible.git -b release-3.7
 
 ### Customizing vars.yaml
 
@@ -138,16 +138,16 @@ which parameters may need to be customized, after running tests
 and which parameters you may want to customize, depending on your environment.
 
 1. Download the files [vars.yaml.template](vars.yaml.template) and
-[ansible-inventory-origin-36-aio](ansible-inventory-origin-36-aio)
+[ansible-inventory-origin-37-aio](ansible-inventory-origin-37-aio)
 
        # curl https://raw.githubusercontent.com/ViaQ/Main/master/vars.yaml.template > vars.yaml.template
-       # curl https://raw.githubusercontent.com/ViaQ/Main/master/ansible-inventory-origin-36-aio > ansible-inventory
+       # curl https://raw.githubusercontent.com/ViaQ/Main/master/ansible-inventory-origin-37-aio > ansible-inventory
 
 To use ViaQ on Red Hat OCP, use the
-[ansible-inventory-ocp-36-aio](ansible-inventory-ocp-36-aio) file instead
-of the origin-36-aio file (you still need vars.yaml.template):
+[ansible-inventory-ocp-37-aio](ansible-inventory-ocp-36-aio) file instead
+of the origin-37-aio file (you still need vars.yaml.template):
 
-    # curl https://raw.githubusercontent.com/ViaQ/Main/master/ansible-inventory-ocp-36-aio > ansible-inventory
+    # curl https://raw.githubusercontent.com/ViaQ/Main/master/ansible-inventory-ocp-37-aio > ansible-inventory
     
 It doesn't matter where you save these files, but you will need to know the
 full path and filename for the `ansible-inventory` and `vars.yaml` files for

--- a/ansible-inventory-ocp-37-aio
+++ b/ansible-inventory-ocp-37-aio
@@ -1,0 +1,37 @@
+
+[OSEv3:children]
+nodes
+masters
+etcd
+
+[OSEv3:vars]
+ansible_connection=local
+openshift_release=v3.7
+openshift_hosted_logging_deploy=true
+openshift_logging_install_logging=true
+short_version=3.7
+openshift_deployment_type=openshift-enterprise
+openshift_logging_namespace=logging
+openshift_logging_image_prefix=registry.access.redhat.com/openshift3/
+openshift_master_identity_providers=[{'mappingMethod': 'lookup', 'challenge': 'true', 'login': 'true', 'kind': 'AllowAllPasswordIdentityProvider', 'name': 'allow_all'}]
+openshift_logging_es_cluster_size=1
+openshift_logging_image_version=v3.7
+deployment_type=openshift-enterprise
+openshift_logging_es_allow_external=True
+openshift_logging_use_mux=True
+openshift_logging_mux_allow_external=True
+openshift_check_min_host_memory_gb=7
+openshift_check_min_host_disk_gb=14
+openshift_disable_check="package_version,docker_storage"
+openshift_logging_mux_file_buffer_storage_type=hostmount
+openshift_logging_elasticsearch_storage_type=hostmount
+openshift_logging_elasticsearch_hostmount_path=/var/lib/elasticsearch
+
+[nodes]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[masters]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[etcd]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True

--- a/ansible-inventory-origin-37-aio
+++ b/ansible-inventory-origin-37-aio
@@ -1,0 +1,41 @@
+
+[OSEv3:children]
+nodes
+masters
+etcd
+
+[OSEv3:vars]
+ansible_connection=local
+openshift_release=v3.7
+openshift_hosted_logging_deploy=true
+openshift_logging_install_logging=true
+short_version=3.7
+openshift_image_tag=latest
+oreg_url=openshift/origin-${component}:latest
+openshift_deployment_type=origin
+openshift_logging_namespace=logging
+openshift_master_identity_providers=[{'mappingMethod': 'lookup', 'challenge': 'true', 'login': 'true', 'kind': 'AllowAllPasswordIdentityProvider', 'name': 'allow_all'}]
+openshift_logging_es_cluster_size=1
+openshift_logging_image_prefix=docker.io/openshift/origin-
+openshift_logging_image_version=latest
+deployment_type=origin
+openshift_logging_es_allow_external=True
+openshift_logging_use_mux=True
+openshift_logging_mux_allow_external=True
+openshift_check_min_host_memory_gb=7
+openshift_check_min_host_disk_gb=14
+openshift_disable_check="package_version,docker_storage"
+openshift_logging_mux_file_buffer_storage_type=hostmount
+openshift_logging_elasticsearch_storage_type=hostmount
+openshift_logging_elasticsearch_hostmount_path=/var/lib/elasticsearch
+openshift_logging_elasticsearch_proxy_image_prefix=docker.io/openshift/
+openshift_logging_elasticsearch_proxy_image_version=v1.1.0
+
+[nodes]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[masters]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True
+
+[etcd]
+localhost storage=True openshift_node_labels="{'region': 'infra'}" openshift_schedulable=True


### PR DESCRIPTION
This adds inventory files for 3.7 and updates README-install.md to
use this version (as opposed to 3.6).  Note that the "etcd" section
is required in the inventory files as of the 3.7 release.  We also require
a different prefix and tag for fetching the oauth-proxy image when using
origin, as these values don't line up with those used for logging images
(and openshift-ansible inherits the settings from the openshift_logging_image_*
variables for oauth-proxy by default).