### PR TITLE
Set the default ES memory limit to 4Gi

### DIFF
--- a/vars.yaml.template
+++ b/vars.yaml.template
@@ -44,6 +44,9 @@ openshift_logging_es_hostname: es.{{ openshift_master_default_subdomain }}
 # the public hostname for common logging ingestion - the fluentd secure_forward listener
 openshift_logging_mux_hostname: mux.{{ openshift_master_default_subdomain }}
 
+# ES tuning parameters
+openshift_logging_es_memory_limit: 4Gi
+
 # mux tuning parameters
 #openshift_logging_mux_file_buffer_limit: 2Gi
 openshift_logging_mux_cpu_limit: 500m


### PR DESCRIPTION
This patch sets the default ES memory limit to 4Gi in our vars.yml
template.  The defalut in openshift-ansible is 8Gi, which can result
in the ES container never being deployed for AIO deployments on
systems with smaller amounts of memory.  Our ViaQ inventory files
set openshift_check_min_host_memory_gb=7, but ES fails to deploy
on systems with 10G of memory unless the memory limit is reduced.